### PR TITLE
Handle overlapping ways

### DIFF
--- a/processing-scripts/05-split-ways-add-bridge-tag/01-JOSM-1-split-way-in-place.js
+++ b/processing-scripts/05-split-ways-add-bridge-tag/01-JOSM-1-split-way-in-place.js
@@ -1,167 +1,269 @@
 import * as console from "josm/scriptingconsole";
+
 const LatLon = Java.type("org.openstreetmap.josm.data.coor.LatLon");
 const Node = Java.type("org.openstreetmap.josm.data.osm.Node");
 const Way = Java.type("org.openstreetmap.josm.data.osm.Way");
 const MainApplication = Java.type("org.openstreetmap.josm.gui.MainApplication");
-const SplitWayAction = Java.type(
-  "org.openstreetmap.josm.actions.SplitWayAction"
-);
+const SplitWayAction = Java.type("org.openstreetmap.josm.actions.SplitWayAction");
 const AddCommand = Java.type("org.openstreetmap.josm.command.AddCommand");
-const SplitWayCommand = Java.type(
-  "org.openstreetmap.josm.command.SplitWayCommand"
-);
 const ChangeCommand = Java.type("org.openstreetmap.josm.command.ChangeCommand");
-const SequenceCommand = Java.type(
-  "org.openstreetmap.josm.command.SequenceCommand"
-);
 const Geometry = Java.type("org.openstreetmap.josm.tools.Geometry");
-const ProjectionRegistry = Java.type(
-  "org.openstreetmap.josm.data.projection.ProjectionRegistry"
-);
-const ArrayList = Java.type("java.util.ArrayList");
-const UndoRedoHandler = Java.type(
-  "org.openstreetmap.josm.data.UndoRedoHandler"
-);
-const OsmPrimitiveType = Java.type(
-  "org.openstreetmap.josm.data.osm.OsmPrimitiveType"
-);
+const ProjectionRegistry = Java.type("org.openstreetmap.josm.data.projection.ProjectionRegistry");
+const UndoRedoHandler = Java.type("org.openstreetmap.josm.data.UndoRedoHandler");
+const OsmPrimitiveType = Java.type("org.openstreetmap.josm.data.osm.OsmPrimitiveType");
+const ChangePropertyCommand = Java.type("org.openstreetmap.josm.command.ChangePropertyCommand");
+
 console.clear();
-// List of coordinates with way IDs
+
+// Constants
+const BRIDGE_TAG = "bridge";
+const BRIDGE_VALUE = "yes";
+
+// Improved coordinate list structure
 const coordinatesList = [
-  [
-    { latitude: 36.99063067649576, longitude: -85.90225171619728, way_id: 108707726 },
-    { latitude: 36.990448735147304, longitude: -85.90199932269573, way_id: 108707726 },
-  ],
-  [
-    { latitude: 36.98806513790712, longitude: -85.90708744181889, way_id: 16082992 },
-    { latitude: 36.987918964647626, longitude: -85.90690103566203, way_id: 16082992 },
-  ],
+  {
+    points: [
+      { latitude: 37.94437953176317, longitude: -84.66657196098026, wayId: 16223905 },
+      { latitude: 37.94451578934621, longitude: -84.666586, wayId: 16223905 }
+    ],
+    bridge_id: "057C00032N"
+  },
 ];
 
-const dataSet = MainApplication.getLayerManager().getEditDataSet();
-if (dataSet !== null) {
-  // Assume only one way is selected
-  for (const coordinates of coordinatesList) {
-    var bridgeEndId = -1;
-    var bridgeStartId = -1;
-    for (var i = 0; i < coordinates.length; i++) {
-      const coord = coordinates[i];
-      // Get the selected way by its ID
-      const selectedWay = dataSet.getPrimitiveById(
-        coord.way_id,
-        OsmPrimitiveType.WAY
-      );
-      const latLon = new LatLon(coord.latitude, coord.longitude);
-      let closestLatLon = new LatLon(coord.latitude, coord.longitude);
-      const projection = ProjectionRegistry.getProjection();
-      const wayNodes = selectedWay.getNodes();
-      let closestIndex = -1;
-      let closestDistance = Infinity;
-      // Find the closest point on the way to the given coordinate
-      for (let i = 0; i < wayNodes.size() - 1; i++) {
-        const segmentStart = projection.latlon2eastNorth(
-          wayNodes.get(i).getCoor()
-        );
-        const segmentEnd = projection.latlon2eastNorth(
-          wayNodes.get(i + 1).getCoor()
-        );
-        const point = Geometry.closestPointToSegment(
-          segmentStart,
-          segmentEnd,
-          projection.latlon2eastNorth(latLon)
-        );
-        const pointLatLon = projection.eastNorth2latlon(point);
-        const distance = latLon.greatCircleDistance(pointLatLon);
-        if (distance < closestDistance) {
-          closestDistance = distance;
-          closestIndex = i;
-          closestLatLon = pointLatLon;
-        }
+function getDataSet() {
+  return MainApplication.getLayerManager().getEditDataSet();
+}
+const BBox = Java.type("org.openstreetmap.josm.data.osm.BBox");
+
+function findClosestWay(lat, lon) {
+  const dataSet = getDataSet();
+  if (!dataSet) {
+    console.println("No active data set found.");
+    return null;
+  }
+
+  const givenPoint = new LatLon(lat, lon);
+  const searchDistanceMeters = 5; // 50 meters search radius
+
+  // Calculate the bounding box
+  const bbox = calculateBBox(givenPoint, searchDistanceMeters);
+
+  // Use JOSM's built-in search functionality with BBox
+  const nearbyWays = dataSet.searchWays(bbox);
+
+  let closestWay = null;
+  let minDistance = Infinity;
+
+  const projection = ProjectionRegistry.getProjection();
+  const pointEN = projection.latlon2eastNorth(givenPoint);
+
+  for (const way of nearbyWays) {
+    const wayNodes = way.getNodes();
+    for (let i = 0; i < wayNodes.size() - 1; i++) {
+      const node1EN = projection.latlon2eastNorth(wayNodes.get(i).getCoor());
+      const node2EN = projection.latlon2eastNorth(wayNodes.get(i + 1).getCoor());
+
+      const closestPointEN = Geometry.closestPointToSegment(node1EN, node2EN, pointEN);
+      const segmentDistance = pointEN.distance(closestPointEN);
+
+      if (segmentDistance < minDistance) {
+        minDistance = segmentDistance;
+        closestWay = way;
       }
-      if (closestIndex !== -1) {
-        const closestNode = new Node(closestLatLon);
-        // console.println(closestNode);
-        const newWayNodes = new java.util.ArrayList(wayNodes);
-        if (i == 0) {
-          bridgeStartId = closestNode.getId();
-        }
-        if (i == coordinates.length - 1) {
-          bridgeEndId = closestNode.getId();
-        }
-        newWayNodes.add(closestIndex + 1, closestNode);
-
-        // Create a new way with the updated node array
-        const newWay = new Way(selectedWay);
-        newWay.setNodes(newWayNodes);
-
-        // Add the new node to the data set and update the way
-        const addCommand = new AddCommand(dataSet, closestNode);
-        UndoRedoHandler.getInstance().add(addCommand);
-        const changeCommand = new ChangeCommand(selectedWay, newWay);
-        UndoRedoHandler.getInstance().add(changeCommand);
-        const nodeArray = Java.to(
-          [closestNode],
-          "org.openstreetmap.josm.data.osm.Node[]"
-        );
-        dataSet.setSelected(closestNode);
-        SplitWayAction.runOn(dataSet);
-
-        // Repaint the map to reflect changes
-        MainApplication.getMap().mapView.repaint();
-
-        console.println(
-          `Node added at latitude: ${coord.latitude}, longitude: ${coord.longitude} and way updated.`
-        );
-      } else {
-        console.println(
-          "Failed to find a suitable segment to insert the node."
-        );
-      }
-    }
-    // After your loop ends
-    console.println("Attempting to find and tag bridge way...");
-
-    // Assuming there's a direct way connecting bridgeStartId and bridgeEndId among the selected ways
-    let bridgeWay = null;
-
-    // Get all selected ways
-    const selectedWays = dataSet.getSelectedWays();
-
-    // Iterate over all selected ways
-    for (const way of selectedWays) {
-      let isBridgeWay = true;
-      let currentNodeId = bridgeStartId;
-
-      // Check if the way contains both start and end nodes in sequence
-      for (const nodeId of way.getNodes().map((node) => node.getId())) {
-        if (nodeId === currentNodeId) {
-          currentNodeId = nodeId;
-          if (currentNodeId === bridgeEndId) break; // Reached end, it's our way
-        } else {
-          isBridgeWay = false; // Sequence broken, not our way
-          break;
-        }
-      }
-
-      if (isBridgeWay && currentNodeId === bridgeEndId) {
-        bridgeWay = way;
-        break;
-      }
-    }
-
-    if (bridgeWay) {
-      // Tag the identified way as a bridge
-      bridgeWay.put("bridge", "yes");
-
-      // Apply the change
-      const changeBridgeTagCommand = new ChangeCommand(bridgeWay, bridgeWay);
-      UndoRedoHandler.getInstance().add(changeBridgeTagCommand);
-
-      console.println("Bridge way tagged successfully.");
-    } else {
-      console.println(
-        "Could not identify a unique way among the selected ones connecting the specified nodes as a bridge."
-      );
     }
   }
+
+  if (closestWay) {
+    // console.println(`Found closest way: ${closestWay.getId()} at distance: ${minDistance} meters`);
+  } else {
+    console.println(`No way found within 5 meters of lat: ${lat}, lon: ${lon}`);
+  }
+
+  return closestWay;
+}
+
+// The calculateBBox function remains the same as in the previous answer
+
+function calculateBBox(center, distanceMeters) {
+  const earthRadiusMeters = 6371000; // Earth's radius in meters
+  const latRadian = center.lat() * Math.PI / 180;
+
+  // Calculate the latitude difference
+  const latDiff = distanceMeters / earthRadiusMeters;
+  // Calculate the longitude difference
+  const lonDiff = distanceMeters / (earthRadiusMeters * Math.cos(latRadian));
+  // Convert differences to degrees
+  const latDiffDegrees = latDiff * 180 / Math.PI;
+  const lonDiffDegrees = lonDiff * 180 / Math.PI;
+
+  // Calculate the corner points
+  const minLat = center.lat() - latDiffDegrees;
+  const maxLat = center.lat() + latDiffDegrees;
+  const minLon = center.lon() - lonDiffDegrees;
+  const maxLon = center.lon() + lonDiffDegrees;
+  // Create and return the BBox
+  return new BBox(new LatLon(minLat, minLon), new LatLon(maxLat, maxLon));
+}
+
+function addNodeToWay(way, latLon, isFirstPoint, preExistingNodeId) {
+  const dataSet = getDataSet();
+  const projection = ProjectionRegistry.getProjection();
+  const wayNodes = way.getNodes();
+  let closestIndex = -1;
+  let closestDistance = Infinity;
+  let closestLatLon = latLon;
+
+  for (let i = 0; i < wayNodes.size() - 1; i++) {
+    const segmentStart = projection.latlon2eastNorth(wayNodes.get(i).getCoor());
+    const segmentEnd = projection.latlon2eastNorth(wayNodes.get(i + 1).getCoor());
+    const point = Geometry.closestPointToSegment(
+      segmentStart,
+      segmentEnd,
+      projection.latlon2eastNorth(latLon)
+    );
+    const pointLatLon = projection.eastNorth2latlon(point);
+    const distance = latLon.greatCircleDistance(pointLatLon);
+    if (distance < closestDistance) {
+      closestDistance = distance;
+      closestIndex = i;
+      closestLatLon = pointLatLon;
+    }
+  }
+
+  if (closestIndex !== -1) {
+    const closestNode = new Node(closestLatLon);
+    const newWayNodes = new java.util.ArrayList(wayNodes);
+    newWayNodes.add(closestIndex + 1, closestNode);
+
+    const newWay = new Way(way);
+    newWay.setNodes(newWayNodes);
+
+    UndoRedoHandler.getInstance().add(new AddCommand(dataSet, closestNode));
+    UndoRedoHandler.getInstance().add(new ChangeCommand(way, newWay));
+
+    console.println(`Node added at latitude: ${latLon.lat()}, longitude: ${latLon.lon()} and Node ID: ${closestNode.getId()}`);
+
+    return closestNode;
+  } else {
+    console.println("Failed to find a suitable segment to insert the node.");
+    return null;
+  }
+}
+
+function tagBridgeWay(startNode, endNode, bridgeId) {
+
+  const dataSet = getDataSet();
+  if (!dataSet) {
+    console.println("No active data set found.");
+    return;
+  }
+  if (startNode) {
+    console.println("Start node found");
+    dataSet.setSelected(startNode);
+    SplitWayAction.runOn(dataSet);
+  }
+  if (endNode) {
+    console.println("End node found");
+    dataSet.setSelected(endNode);
+    SplitWayAction.runOn(dataSet);
+  }
+  const selectedWays = dataSet.getSelectedWays();
+  for (const way of selectedWays) {
+    if (startNode && endNode) {
+      const wayNodes = way.getNodes();
+      const wayNodeIds = wayNodes.map(node => node.getId());
+
+      if ((wayNodes[0] === startNode && wayNodes[wayNodes.length - 1] === endNode) || (wayNodes[0] === endNode && wayNodes[wayNodes.length - 1] === startNode)) {
+        const addTagCommand = new ChangePropertyCommand(way, BRIDGE_TAG, BRIDGE_VALUE);
+        UndoRedoHandler.getInstance().add(addTagCommand);
+        const addBridgeIdCommand = new ChangePropertyCommand(way, "bridge:id", bridgeId);
+        UndoRedoHandler.getInstance().add(addBridgeIdCommand);
+        console.println(`Bridge way ${way.getId()} tagged successfully.`);
+        return;
+      }
+    } else {
+      if (endNode) {
+        const wayNodes = way.getNodes();
+        const wayNodeIds = wayNodes.map(node => node.getId());
+        if (wayNodes[wayNodes.length - 1] === endNode) {
+          const addTagCommand = new ChangePropertyCommand(way, BRIDGE_TAG, BRIDGE_VALUE);
+          UndoRedoHandler.getInstance().add(addTagCommand);
+          const addBridgeIdCommand = new ChangePropertyCommand(way, "bridge:id", bridgeId);
+          UndoRedoHandler.getInstance().add(addBridgeIdCommand);
+          console.println(`Bridge way ${way.getId()} tagged successfully.`);
+          return;
+        }
+      }
+      else if (startNode) {
+        const wayNodes = way.getNodes();
+        const wayNodeIds = wayNodes.map(node => node.getId());
+        if (wayNodes[0] === startNode) {
+          const addTagCommand = new ChangePropertyCommand(way, BRIDGE_TAG, BRIDGE_VALUE);
+          UndoRedoHandler.getInstance().add(addTagCommand);
+          const addBridgeIdCommand = new ChangePropertyCommand(way, "bridge:id", bridgeId);
+          UndoRedoHandler.getInstance().add(addBridgeIdCommand);
+          console.println(`Bridge way ${way.getId()} tagged successfully.`);
+          return;
+        }
+      }
+    }
+  }
+  console.println("Could not identify a unique way among the selected ones connecting the specified nodes as a bridge.");
+}
+
+function processCoordinateSet(coordinateSet) {
+  const dataSet = getDataSet();
+  if (!dataSet) {
+    console.println("No active data set found.");
+    return;
+  }
+
+  const { points, bridge_id } = coordinateSet;
+  const wayId = points[0].wayId;
+  let startNode, endNode = null;
+
+  for (let i = 0; i < points.length; i++) {
+    const point = points[i];
+    // const way = dataSet.getPrimitiveById(point.wayId, OsmPrimitiveType.WAY);
+    const way = findClosestWay(point.latitude, point.longitude);
+    const closestWayId = way.getId();
+
+    if (!way) {
+      console.println(`Way not found for point ${i}`);
+      return;
+    }
+    if (closestWayId !== wayId && closestWayId >= 0 && way.hasTag("bridge:id")) {
+      continue
+    }
+    if (point.latitude == -1 && point.longitude == -1) {
+      continue;
+    }
+    else {
+      const node = addNodeToWay(way, new LatLon(point.latitude, point.longitude));
+      if (i === 0) endNode = node;
+      if (i === points.length - 1) startNode = node;
+    }
+
+  }
+
+  if (startNode || endNode) {
+    tagBridgeWay(startNode, endNode, bridge_id);
+  } else {
+    const way = dataSet.getPrimitiveById(wayId, OsmPrimitiveType.WAY);
+    const addTagCommand = new ChangePropertyCommand(way, BRIDGE_TAG, BRIDGE_VALUE);
+    UndoRedoHandler.getInstance().add(addTagCommand);
+    const addBridgeIdCommand = new ChangePropertyCommand(way, "bridge:id", bridge_id);
+    UndoRedoHandler.getInstance().add(addBridgeIdCommand);
+  }
+
+  MainApplication.getMap().mapView.repaint();
+}
+
+// Main execution
+try {
+  for (const coordinateSet of coordinatesList) {
+    processCoordinateSet(coordinateSet);
+  }
+} catch (error) {
+  console.println(`An error occurred: ${error.message}`);
 }


### PR DESCRIPTION
- Compare whole node objects instead of node id.
- Because of unrealiable wayID first find nearby ways and find the nearest way then compare the wayID.
- Fixed edge cases where two different bridge overlaps on the same way.

Fixed Now only correct way is getting tagged
<img width="585" alt="image" src="https://github.com/user-attachments/assets/78ad086c-bc24-4b5b-b950-32f209cb8234">
Earlier whole way was getting tagged
<img width="505" alt="image" src="https://github.com/user-attachments/assets/6b7200fb-f844-48c5-b3b3-867dbfb37917">
